### PR TITLE
Update gtfs.clj

### DIFF
--- a/src/transit/gtfs.clj
+++ b/src/transit/gtfs.clj
@@ -1,5 +1,5 @@
 (ns transit.gtfs
-    "Google Transit Feed Specification"
+    "General Transit Feed Specification"
     )
 
 ; Google Transit transport modes (incomplete)


### PR DESCRIPTION
No longer referred to as Google Transit Feed Specification
